### PR TITLE
feat: `message_to_sign` ignores data that are not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.0.4] - 2020-11-26
+### Added
+- `generate_sso_request_params` throws on empty PK
+
+### Changed
+- join operator for `message_to_sign` is now `&`
+- `message_to_sign` ignores data that are not set
+
+### Fixed
+- ensure testing `throws` is working correctly
+- rubocop offences
+
 ## [0.0.3] - 2020-11-25
 ### Added
 - Logo and badges to README

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,9 +1,5 @@
 # Silkey-SDK for Ruby
 
-[logo]
-
-[slogan]
-
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies.  

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,5 @@
 source 'https://rubygems.org'
 
-# git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
-
-# Specify your gem's dependencies in andromeda.gemspec
-
-#source 'https://hwGZD769AGZu5Wyzp87F@repo.fury.io/silkey/' do
-#  gem 'ethereum.rb', '~> 2.2.3'
-#end
-
 gemspec
 
 gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    silkey-sdk (0.0.3)
+    silkey-sdk (0.0.4)
       activesupport (~> 6.0)
       eth (~> 0.4.12)
       ethereum.rb (~> 2.5)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![Silkey Logo](https://raw.githubusercontent.com/Silkey-Team/brand/master/silkey-word-black.png)
-
 # Silkey SDK for Ruby
+
+![Silkey Logo](https://raw.githubusercontent.com/Silkey-Team/brand/master/silkey-word-black.png)
 
 [![GitHub version](https://badge.fury.io/gh/Silkey-Team%2Fsilkey-sdk.svg)](https://badge.fury.io/gh/Silkey-Team%2Fsilkey-sdk)
 [![Gem Version](https://badge.fury.io/rb/silkey-sdk.svg)](https://badge.fury.io/rb/silkey-sdk)
@@ -32,14 +32,14 @@ end
 | signature        | yes       | string   | Domain owner signature
 | ssoTimestamp     | yes       | number   | Time of signing SSO request
 | redirectUrl      | yes       | string   | Where to redirect user with token after sign in
-| redirectMethod   | no        | GET/POST | How to redirect user after sign in, default is POST
 | cancelUrl        | yes       | string   | Where to redirect user on error
+| redirectMethod   | no        | GET/POST | How to redirect user after sign in, default is POST
 | refId            | no        | string   | It will be return with user token, you may use it to identify request
 | scope            | no        | string   | Scope of data to return in a token payload: `id` (default) returns only user address, `email` returns address + email
 
 
 ```rb
-params = { :redirectUrl => 'https://your-website', :refId => '12ab' }
+params = { redirectUrl: 'https://your-website', refId: '12ab' }
 sso_params = Silkey::SDK.generate_sso_request_params(private_key, params)
 ```
 

--- a/lib/silkey/models/jwt_payload.rb
+++ b/lib/silkey/models/jwt_payload.rb
@@ -68,7 +68,6 @@ module Silkey
         self.silkey_signature_timestamp = timestamp
         self
       end
-
       # rubocop:enable Naming/AccessorMethodName
 
       ##
@@ -78,20 +77,9 @@ module Silkey
           self.user_signature_timestamp = Silkey::Utils.current_timestamp
         end
 
-        str1_hex = 'address'.unpack('H*')[0]
-        adr_hex = Silkey::Utils.remove0x(address).downcase
+        return pack_payload_to_hex if Silkey::Utils.empty?(user_signature_timestamp)
 
-        str2_hex = [
-          'refId', ref_id.to_s,
-          'scope', scope,
-          'userSignatureTimestamp'
-        ].map { |str| str.to_s.unpack('H*') }.join('')
-
-        str_hex = "#{str1_hex}#{adr_hex}#{str2_hex}"
-
-        return str_hex if Silkey::Utils.empty?(user_signature_timestamp)
-
-        "#{str_hex}#{Silkey::Utils.int_to_hex(user_signature_timestamp.to_s)}"
+        "#{pack_payload_to_hex}#{Silkey::Utils.int_to_hex(user_signature_timestamp.to_s)}"
       end
 
       def message_to_sign_by_silkey
@@ -130,7 +118,7 @@ module Silkey
           if k == 'scope'
             set_scope(v)
           else
-            self.instance_variable_set("@#{var}", v)
+            instance_variable_set("@#{var}", v)
           end
         end
 
@@ -138,6 +126,19 @@ module Silkey
       end
 
       private
+
+      def pack_payload_to_hex
+        str1_hex = 'address'.unpack('H*')[0]
+        adr_hex = Silkey::Utils.remove0x(address).downcase
+
+        str2_hex = [
+          'refId', ref_id.to_s,
+          'scope', scope,
+          'userSignatureTimestamp'
+        ].map { |str| str.to_s.unpack('H*') }.join('')
+
+        "#{str1_hex}#{adr_hex}#{str2_hex}"
+      end
 
       def validate_scope_email
         raise 'email is empty' if Silkey::Utils.empty?(email)

--- a/lib/silkey/registry_contract/registry_contract.rb
+++ b/lib/silkey/registry_contract/registry_contract.rb
@@ -26,7 +26,7 @@ module Silkey # :nodoc: all
       {
         name: CONTRACT_NAME,
         address: Configuration.registry_contract_address,
-        abi: Configuration.registry_contract_abi,
+        abi: Configuration.registry_contract_abi
       }.freeze
     end
   end

--- a/lib/silkey/services/logger_service.rb
+++ b/lib/silkey/services/logger_service.rb
@@ -7,7 +7,7 @@ module Silkey # :nodoc: all
 
       def logger
         if @logger.nil?
-          @logger = Logger.new(STDOUT)
+          @logger = Logger.new($stdout)
           @logger.level = Logger::INFO
           @logger.datetime_format = '%a %d-%m-%Y %H%M '
         end

--- a/lib/silkey/version.rb
+++ b/lib/silkey/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Silkey
-  VERSION = '0.0.3'
+  VERSION = '0.0.4'
 end

--- a/silkey-sdk.gemspec
+++ b/silkey-sdk.gemspec
@@ -16,15 +16,15 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/Silkey-Team/ruby-sdk'
   spec.licenses = ['MIT']
 
-  # spec.files       = ["lib/sdk.rb"]
+  # spec.files       = ['lib/sdk.rb']
 
   spec.metadata = {
-    "bug_tracker_uri" => "https://github.com/Silkey-Team/ruby-sdk/issues",
-    "changelog_uri" => "https://github.com/Silkey-Team/ruby-sdk/blob/master/CHANGELOG.md",
-    "documentation_uri" => "https://www.rubydoc.info/gems/silkey-sdk/" + Silkey::VERSION,
-    "homepage_uri" => "https://silkey.io",
-    "source_code_uri" => "https://github.com/Silkey-Team/ruby-sdk",
-    # "wiki_uri"          => "https://example.com/user/bestgemever/wiki"
+    'bug_tracker_uri' => 'https://github.com/Silkey-Team/ruby-sdk/issues',
+    'changelog_uri' => 'https://github.com/Silkey-Team/ruby-sdk/blob/master/CHANGELOG.md',
+    'documentation_uri' => "https://www.rubydoc.info/gems/silkey-sdk/#{Silkey::VERSION}",
+    'homepage_uri' => 'https://silkey.io',
+    'source_code_uri' => 'https://github.com/Silkey-Team/ruby-sdk'
+    # 'wiki_uri'          => 'https://example.com/user/bestgemever/wiki'
   }
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
@@ -44,18 +44,18 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
   spec.add_dependency 'activesupport', '~> 6.0'
-  spec.add_dependency 'jwt', '~> 2.2.2'
   spec.add_dependency 'eth', '~> 0.4.12'
   spec.add_dependency 'ethereum.rb', '~> 2.5'
+  spec.add_dependency 'jwt', '~> 2.2.2'
   spec.add_dependency 'virtus', '~> 1.0'
   spec.add_dependency 'virtus_convert', '~> 0.1'
-  spec.add_development_dependency 'rdoc', '~> 6.2', '>= 6.2.1'
-  spec.add_development_dependency 'yard', '~> 0.9.25'
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'factory_bot', '~> 6.1'
   spec.add_development_dependency 'pry', '~> 0.13'
   spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rdoc', '~> 6.2', '>= 6.2.1'
   spec.add_development_dependency 'rspec', '~> 3.10'
   spec.add_development_dependency 'rubocop', '~> 1.3'
   spec.add_development_dependency 'rubocop-performance', '~> 1.8'
+  spec.add_development_dependency 'yard', '~> 0.9.25'
 end

--- a/spec/models/jwt_payload_spec.rb
+++ b/spec/models/jwt_payload_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Silkey::Models::JwtPayload, type: :model do
         expect { subject.validate }.to_not raise_error
       end
 
-      it 'raise error when missing data, scope ID' do
+      it 'raise error when missing data, scope EMAIL' do
         subject.set_scope('email')
         subject.set_address(addr)
         subject.set_user_signature(sig, 1)
@@ -120,15 +120,15 @@ RSpec.describe Silkey::Models::JwtPayload, type: :model do
 
   describe 'import' do
     it 'expect to import data from hash to obejct' do
-      payload = { "scope" => "id",
-                  "silkeySignature" => nil,
-                  "silkeySignatureTimestamp" => nil,
-                  "userSignature" => "0xc9d8287da2304225cf1040a72055cbdec21709b70b30e384d6e4b13422"\
-                                     "ee219178403342828a850dc449782c935ca1bc7033fd89c313202868b293"\
-                                     "9b2d05430f1c",
-                  "userSignatureTimestamp" => 1604688865,
-                  "address" => "0xcfA6bED7B5681CFa3AdF53bF31eB3cd06993cADe",
-                  "iat" => 1604688865 }
+      payload = { 'scope' => 'id',
+                  'silkeySignature' => nil,
+                  'silkeySignatureTimestamp' => nil,
+                  'userSignature' => '0xc9d8287da2304225cf1040a72055cbdec21709b70b30e384d6e4b13422'\
+                                     'ee219178403342828a850dc449782c935ca1bc7033fd89c313202868b293'\
+                                     '9b2d05430f1c',
+                  'userSignatureTimestamp' => 1_604_688_865,
+                  'address' => '0xcfA6bED7B5681CFa3AdF53bF31eB3cd06993cADe',
+                  'iat' => 1_604_688_865 }
 
       imported = subject.import(payload)
 

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -159,11 +159,12 @@ RSpec.describe Silkey::Utils do
       expect(subject.verify_message(message, signature)).to eq(public_key)
     end
 
-    it 'signs SDL message in ETH way' do
-      custom_sdk_message = 'cancelUrl=::redirectUrl=::refId=::scope=::ssoTimestamp=1602151787'
+    it 'signs SDK message in ETH way' do
+      custom_sdk_message = 'cancelUrl=&redirectUrl=&refId=&scope=id&ssoTimestamp=1602151787'
       signature = subject.sign_message(private_key, custom_sdk_message)
       # puts signature
       expect(subject.verify_message(custom_sdk_message, signature)).to eq(public_key)
+      expect(subject.verify_message("#{custom_sdk_message}.", signature)).to_not eq(public_key)
     end
   end
 end


### PR DESCRIPTION
- join operator for `message_to_sign` is now `&`
- `generate_sso_request_params` throws on empty PK
- ensure testing `throws` is working correctly
- fix rubocop offences